### PR TITLE
add transformers; handle multi-line text

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,8 @@
 Package: roxygen2md
 Title: 'Roxygen' to 'Markdown'
-Version: 0.0-2
-Authors@R: person("Kirill", "Müller", role = c("aut", "cre"), email = "krlmlr+r@mailbox.org")
+Version: 0.0-3
+Authors@R: c(person("Kirill", "Müller", role = c("aut", "cre"), email = "krlmlr+r@mailbox.org"),
+    person("Heather", "Turner", role = c("ctb")))
 Description: Converts elements of 'roxygen' documentation to 'markdown'.
 Imports:
     BBmisc,
@@ -15,8 +16,8 @@ Remotes:
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-Date: 2017-02-03
+Date: 2017-08-25
 BugReports: https://github.com/krlmlr/roxygen2md/issues
 URL: https://github.com/krlmlr/roxygen2md, http://krlmlr.github.io/roxygen2md
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "pkgapi::api_roclet"))
-RoxygenNote: 6.0.1
+RoxygenNote: 6.0.1.9000

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+## roxygen2md 0.0-3 (2017-08-25)
+
+- Now replaces `\emph`, `\bold` and `\url` with corresponding markdown.
+- Now handles Rd markup split over multiple lines, e.g. 
+
+          #' Author, A. (2017) An Important Reference. \emph{Journal of 
+          #' Critical Research}, \bold{5}(2), 1--10.
+
 ## roxygen2md 0.0-2 (2017-02-03)
 
 - Now uses global replacement again.

--- a/R/md.R
+++ b/R/md.R
@@ -25,6 +25,9 @@ roxygen2md_local <- function() {
     convert_S4_code_links,
     convert_S4_links,
     convert_code,
+    convert_emph,
+    convert_bold,
+    convert_url,
     NULL)
 
   add_roxygen_field()
@@ -69,7 +72,7 @@ convert_local_links <- function(text) {
     text,
     rex::rex(
       "\\code{\\link{",
-      capture(one_or_more(none_of("}[%"))),
+      capture(one_or_more(none_of("}["))),
       "}",
       maybe("()"),
       "}"
@@ -83,9 +86,9 @@ convert_alien_links <- function(text) {
     text,
     rex::rex(
       "\\code{\\link[",
-      capture(one_or_more(none_of("][%"))),
+      capture(one_or_more(none_of("]["))),
       "]{",
-      capture(one_or_more(none_of("}[%"))),
+      capture(one_or_more(none_of("}["))),
       "}",
       maybe("()"),
       "}"
@@ -99,7 +102,7 @@ convert_S4_code_links <- function(text) {
     text,
     rex::rex(
       "\\code{\\linkS4class{",
-      capture(one_or_more(none_of("}%"))),
+      capture(one_or_more(none_of("}"))),
       "}}"
     ),
     "[\\1-class]")
@@ -111,7 +114,7 @@ convert_S4_links <- function(text) {
     text,
     rex::rex(
       "\\linkS4class{",
-      capture(one_or_more(none_of("}%"))),
+      capture(one_or_more(none_of("}"))),
       "}"
     ),
     "[\\1-class]")
@@ -123,8 +126,44 @@ convert_code <- function(text) {
     text,
     rex::rex(
       "\\code{",
-      capture(one_or_more(none_of("{}%"))),
+      capture(one_or_more(none_of("{}"))),
       "}"
     ),
     "`\\1`")
+}
+
+convert_emph <- function(text) {
+  rex::re_substitutes(
+    global = TRUE,
+    text,
+    rex::rex(
+      "\\emph{",
+      capture(one_or_more(none_of("{}"))),
+      "}"
+    ),
+    "*\\1*")
+}
+
+convert_bold <- function(text) {
+  rex::re_substitutes(
+    global = TRUE,
+    text,
+    rex::rex(
+      "\\bold{",
+      capture(one_or_more(none_of("{}"))),
+      "}"
+    ),
+    "**\\1**")
+}
+
+convert_url <- function(text) {
+  rex::re_substitutes(
+    global = TRUE,
+    text,
+    rex::rex(
+      "\\url{",
+      capture(one_or_more(none_of("{}"))),
+      "}"
+    ),
+    "\\1")
 }

--- a/R/transform.R
+++ b/R/transform.R
@@ -3,11 +3,11 @@ transform_files <- function(files, transformers) {
     roxy_lines <- get_roxy_lines(text)
 
     new_text <- text
-    text <- paste(text[roxy_lines], collapse = "\n")
-    new_text[roxy_lines] <- split(Reduce(
+    collapsed_text <- paste(text[roxy_lines], collapse = "\n")
+    new_text[roxy_lines] <- strsplit(Reduce(
       function(text, transformer) transformer(text),
       transformers,
-      init = text), "\n")[[1]]
+      init = collapsed_text), "\n")[[1]]
 
     new_text
   }

--- a/R/transform.R
+++ b/R/transform.R
@@ -3,10 +3,11 @@ transform_files <- function(files, transformers) {
     roxy_lines <- get_roxy_lines(text)
 
     new_text <- text
-    new_text[roxy_lines] <- Reduce(
+    text <- paste(text[roxy_lines], collapse = "\n")
+    new_text[roxy_lines] <- split(Reduce(
       function(text, transformer) transformer(text),
       transformers,
-      init = text[roxy_lines])
+      init = text), "\n")[[1]]
 
     new_text
   }


### PR DESCRIPTION
Addresses issues raised in issue #5:

- new transformers for \bold, \emph, \url.
- transformers now applied to concatenated text, so that Rd markup split over multiple lines is still transformed.

Closes #5.