### PR TITLE
Replacing utf8 by enc (package renamed)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,10 +9,10 @@ Imports:
     desc,
     rex,
     rprojroot,
-    utf8,
+    enc,
     withr
 Remotes:
-    krlmlr/utf8
+    krlmlr/enc
 License: GPL-3
 Encoding: UTF-8
 LazyData: true

--- a/R/transform.R
+++ b/R/transform.R
@@ -12,7 +12,7 @@ transform_files <- function(files, transformers) {
     new_text
   }
 
-  changed <- utf8::transform_lines_enc(files, transformer)
+  changed <- enc::transform_lines_enc(files, transformer)
   if (any(changed)) {
       message("Please review the changes carefully!")
   }


### PR DESCRIPTION
Installation via devtools was failing, because of utf8 changed name.